### PR TITLE
Expose datepicker object

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,30 @@ export class AppComponent {
 }
 ```
 
+## Daterangepicker methods
+
+You can programmatically update the `startDate` and `endDate` in the picker using the `setStartDate` and `setEndDate` methods. You can access the Date Range Picker object and its functions and properties through the `datePicker` property of the directive using `@ViewChild`.
+
+``` javascript
+import { Component, AfterViewInit, ViewChild  } from '@angular/core';
+import { DaterangePickerComponent } from 'ng2-daterangepicker';
+
+@Component({
+    selector:'my-app',
+    template:'<h3>Component Template</h3>'
+})
+export class AppComponent {
+
+    @ViewChild(DaterangePickerComponent)
+    private picker: DaterangePickerComponent;
+
+    public updateDateRange() {
+        this.picker.datePicker.setStartDate('2017-03-27');
+        this.picker.datePicker.setEndDate('2017-04-08');
+    }
+}
+```
+
 ## Using Daterangepicker Events
 
 You can bind to the events fired by the daterangepicker. All events will emit an object containing the event fired and the datepicker object.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-daterangepicker",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Angular 2 DaterangePicker component",
   "scripts": {
     "watch": "tsc -p src -w",

--- a/src/daterangepicker/daterangepicker.component.ts
+++ b/src/daterangepicker/daterangepicker.component.ts
@@ -22,6 +22,8 @@ export class DaterangePickerComponent implements AfterViewInit, OnDestroy {
     @Output() hideDaterangepicker = new EventEmitter();
     @Output() showDaterangepicker = new EventEmitter();
 
+    public datePicker: any;
+
     constructor(private input: ElementRef, private config: DaterangepickerConfig) { }
 
     ngAfterViewInit() {
@@ -34,6 +36,8 @@ export class DaterangePickerComponent implements AfterViewInit, OnDestroy {
         // cast $ to any to avoid jquery type checking
         //$(this.input.nativeElement).daterangepicker(targetOptions, this.callback.bind(this));
         (<any>$(this.input.nativeElement)).daterangepicker(targetOptions, this.callback.bind(this));
+
+        this.datePicker = (<any>$(this.input.nativeElement)).data('daterangepicker');
 
         $(this.input.nativeElement).on('cancel.daterangepicker',
             (e:any, picker:any) => {


### PR DESCRIPTION
Exposed the datepicker object allowing parent components to pro grammatically update the startDate and endDate.

The latest release v2.0.5 should fix issue #9 