### PR TITLE
Reattach events when rerendering

### DIFF
--- a/src/app/daterangepicker/daterangepicker.component.ts
+++ b/src/app/daterangepicker/daterangepicker.component.ts
@@ -126,6 +126,7 @@ export class DaterangePickerComponent implements AfterViewInit, OnDestroy, DoChe
 
         if(optionsChanged || settingsChanged) {
             this.render();
+            this.attachEvents();
             if(this.activeRange && this.datePicker) {
                 this.datePicker.setStartDate(this.activeRange.start);
                 this.datePicker.setEndDate(this.activeRange.end);


### PR DESCRIPTION
Hello,

I just noticed that when changing the options or the settings (filling the condition in `ngDoCheck()`), `this.render()` was called and apparently changing the reference of the element, thus preventing the events to be fired.

My use case was the following:
2 datepickers (single for that matter), the first one changing the `minDate` of the second one.
When I selected a date for the first one, the minDate worked perfectly, but the `(applyDaterangepicker)` event wasn't firing anymore, leading to issues in my side.

By calling `attachEvents()` after `render()` it works perfectly :)

I hope it makes sense.

Thanks.