### PR TITLE
explicitly setting "sideEffects" property in package.json

### DIFF
--- a/projects/ng2-daterangepicker/package.json
+++ b/projects/ng2-daterangepicker/package.json
@@ -19,5 +19,6 @@
     "tslib": "^1.10.0",
     "jquery": "^3.4.1",
     "@types/jquery": "^3.3.32"
-  }
+  },
+  "sideEffects": ["*.css"]
 }


### PR DESCRIPTION
This fixes #139

Apparently if you set the "sideEffects" property in the project's `package.json` file, Angular CLI will respect that when building the project.  I ran `ng build ng2-daterangepicker` after making this change and it output this in the generated package.json file:

```
"sideEffects": [
    "*.css"
  ],
```